### PR TITLE
Add Elixir posts from my blog

### DIFF
--- a/elixir/config.ini
+++ b/elixir/config.ini
@@ -91,3 +91,6 @@ name = Lobste.rs Elixir Links
 
 [http://blog.scottnelsonsmith.com/my_elixir_blog/feed.xml]
 name = Old Fart's Elixir Musings
+
+[http://stratus3d.com/blog/categories/elixir/atom.xml]
+name = Stratus3D - Elixir


### PR DESCRIPTION
My Elixir-specific atom feed is located at http://stratus3d.com/blog/categories/elixir/atom.xml