### PR TITLE
Add elixir feed from wsmoak.net

### DIFF
--- a/elixir/config.ini
+++ b/elixir/config.ini
@@ -97,3 +97,6 @@ name = Stratus3D - Elixir
 
 [http://cursingthedarkness.com/feeds/posts/default/-/elixir]
 name = Cursing the Darkness
+
+[http://wsmoak.net/tag/elixir.xml]
+Wendy Smoak - Elixir


### PR DESCRIPTION
Adds the feed for the elixir tag at http://wsmoak.net

(When editing, I noticed that the apostrophe on line 93 breaks the syntax highlighting. Not sure if it causes any problems other than that.)
